### PR TITLE
Use a table for file descriptors reuse.

### DIFF
--- a/src/logging/file.lua
+++ b/src/logging/file.lua
@@ -6,26 +6,22 @@
 -- @copyright 2004-2013 Kepler Project
 --
 -------------------------------------------------------------------------------
-
 local logging = require"logging"
+logging_fileHandler = {} -- store the file handlers
 
-local lastFileNameDatePattern
-local lastFileHandler
-
-local openFileLogger = function (filename, datePattern)
+function openFileLogger(filename, datePattern)
 	local filename = string.format(filename, os.date(datePattern))
-	if (lastFileNameDatePattern ~= filename) then
-		local f = io.open(filename, "a")
+	if logging_fileHandler[filename] == nil then
+		f = io.open(filename, "a")
 		if (f) then
 			f:setvbuf ("line")
-			lastFileNameDatePattern = filename
-			lastFileHandler = f
+			logging_fileHandler[filename] = f
 			return f
 		else
 			return nil, string.format("file `%s' could not be opened for writing", filename)
 		end
 	else
-		return lastFileHandler
+		return logging_fileHandler[filename]
 	end
 end
 
@@ -46,4 +42,3 @@ function logging.file(filename, datePattern, logPattern)
 end
 
 return logging.file
-


### PR DESCRIPTION
The current method for file descriptors reuse was leaking file descriptors when more than one file logger was used since you used a local variable which updated the last used file.

If you happen to log on one file then on another you ended opening a file again.

This patch uses a global table to maintain the file descriptor for each open file.